### PR TITLE
fix compiler error if EEPROM is used

### DIFF
--- a/src/ESP_WiFiManager_Lite.h
+++ b/src/ESP_WiFiManager_Lite.h
@@ -1276,6 +1276,8 @@ class ESP_WiFiManager_Lite
 
     bool extLoadDynamicData()
     {
+#if ( USE_LITTLEFS || USE_SPIFFS )
+
   #if ESP8266
       // SPIFFS and LittleFS do auto-format if not yet
       if (!FileFS.begin())
@@ -1289,12 +1291,20 @@ class ESP_WiFiManager_Lite
       }
 
       return loadDynamicData();
+
+#else   // #if ( USE_LITTLEFS || USE_SPIFFS )
+
+      return EEPROM_getDynamicData();
+
+#endif   // #if ( USE_LITTLEFS || USE_SPIFFS )
     }
 
     //////////////////////////////////////////////
 
     void extSaveDynamicData()
     {
+#if ( USE_LITTLEFS || USE_SPIFFS )
+
   #if ESP8266
       // SPIFFS and LittleFS do auto-format if not yet
       if (!FileFS.begin())
@@ -1308,6 +1318,12 @@ class ESP_WiFiManager_Lite
       }
 
       saveDynamicData();
+
+#else   // #if ( USE_LITTLEFS || USE_SPIFFS )
+
+      EEPROM_putDynamicData();
+
+#endif   // #if ( USE_LITTLEFS || USE_SPIFFS )
     }
 
 #endif


### PR DESCRIPTION
See [Issue 28 on ESPAsync_WiFiManager_Lite](https://github.com/khoih-prog/ESPAsync_WiFiManager_Lite/issues/28).